### PR TITLE
fix: Version mismatches and clarify Xcode requirement

### DIFF
--- a/HomeKit Automator/HomeKit AutomatorTests/HomeKit_AutomatorTests.swift
+++ b/HomeKit Automator/HomeKit AutomatorTests/HomeKit_AutomatorTests.swift
@@ -368,11 +368,11 @@ struct HelperAPIResponseTests {
 
     @Test func statusResponseDecoding() throws {
         let json = """
-        {"status": "ok", "version": "1.1.0", "uptime": 3600.5}
+        {"status": "ok", "version": "1.2.0", "uptime": 3600.5}
         """
         let response = try JSONDecoder().decode(StatusResponse.self, from: Data(json.utf8))
         #expect(response.status == "ok")
-        #expect(response.version == "1.1.0")
+        #expect(response.version == "1.2.0")
         #expect(response.uptime == 3600.5)
     }
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will handle the Homebrew formula installation and OpenClaw plugin configura
 - macOS 14.0 (Sonoma) or later
 - **Xcode 16+** (full Xcode.app from the App Store, not just Command Line Tools)
   - Command Line Tools alone will **not work** — XCTest framework is required for tests
-  - After installing Xcode, run: `sudo xcode-select --switch /Applications/Xcode.app`
+  - After installing Xcode, run: `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
 - Swift 6.0 (included with Xcode 16+)
 - XcodeGen (`brew install xcodegen`)
 - Node.js 20+

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ This will handle the Homebrew formula installation and OpenClaw plugin configura
 #### Prerequisites
 
 - macOS 14.0 (Sonoma) or later
-- Xcode 16+ with Swift 6.0
+- **Xcode 16+** (full Xcode.app from the App Store, not just Command Line Tools)
+  - Command Line Tools alone will **not work** — XCTest framework is required for tests
+  - After installing Xcode, run: `sudo xcode-select --switch /Applications/Xcode.app`
+- Swift 6.0 (included with Xcode 16+)
 - XcodeGen (`brew install xcodegen`)
 - Node.js 20+
 - Apple Developer account (free tier works, but you need HomeKit capability)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -31,7 +31,10 @@ This guide walks through every step of installing, configuring, and verifying Ho
 **Important:** You must install the full **Xcode.app** from the App Store, not just the Command Line Tools. The XCTest framework is required for running tests and is only available in the full Xcode installation. After installing Xcode, run:
 
 ```bash
-sudo xcode-select --switch /Applications/Xcode.app
+# Point xcode-select at the Xcode Developer directory
+sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+# You can verify or discover the current path with:
+# xcode-select -p
 ```
 
 Additional requirements:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,12 +21,18 @@ This guide walks through every step of installing, configuring, and verifying Ho
 | Requirement | Minimum | Recommended |
 |------------|---------|-------------|
 | macOS | 14.0 (Sonoma) | 15.0+ (Sequoia) |
-| Xcode | 16.0 | 16.2+ |
+| Xcode | 16.0 (full Xcode.app) | 16.2+ |
 | Swift | 6.0 | 6.0+ |
 | Node.js | 20.0 | 22 LTS |
 | XcodeGen | 2.38 | Latest |
 | RAM | 4 GB | 8 GB+ |
 | Disk | 500 MB | 1 GB |
+
+**Important:** You must install the full **Xcode.app** from the App Store, not just the Command Line Tools. The XCTest framework is required for running tests and is only available in the full Xcode installation. After installing Xcode, run:
+
+```bash
+sudo xcode-select --switch /Applications/Xcode.app
+```
 
 Additional requirements:
 

--- a/scripts/mcp-server/package.json
+++ b/scripts/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-automator-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MCP server for HomeKit Automator — smart home control and automation via natural language",
   "type": "module",
   "main": "index.js",

--- a/scripts/openclaw-plugin/plugin.json
+++ b/scripts/openclaw-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-automator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Smart HomeKit automation with natural language — control devices, create automations registered as Apple Shortcuts, get energy insights and suggestions. Multi-home support, full validation pipeline, condition evaluation, and structured logging.",
   "author": "homekit-automator",
   "license": "MIT",


### PR DESCRIPTION
## Summary
This PR fixes critical issues discovered during thorough testing and installation of the homekit-automator skill after PR #11 was merged.

## Issues Found and Fixed

### 1. Version Mismatches ⚠️ (Critical)
After PR #11 merged updating the project to v1.2.0, several files were left at v1.1.0:
- `scripts/openclaw-plugin/plugin.json` → Updated to 1.2.0
- `scripts/mcp-server/package.json` → Updated to 1.2.0  
- `HomeKit Automator/HomeKit AutomatorTests/HomeKit_AutomatorTests.swift` → Test assertions updated to expect 1.2.0

All version references now consistently reflect **1.2.0** across the codebase.

### 2. XCTest Module Not Found 🚫 (Installation Blocker)
Swift tests fail when only Xcode Command Line Tools are installed:
```
error: no such module 'XCTest'
```

**Root Cause:** XCTest framework is only available in the full Xcode.app from the App Store, not in the Command Line Tools package.

**Impact:** This was a critical blocker for anyone trying to:
- Run `make test-swift`
- Contribute to the project  
- Verify their installation works

**Fix:** Updated documentation to explicitly state full Xcode is required:
- **README.md** — Added explicit note that full Xcode.app is needed (not just CLT) with xcode-select command
- **docs/setup.md** — Added prominent warning box with xcode-select setup instructions

## What Was Tested

### ✅ Build & Compilation
- CLI builds successfully: `swift build` (0.92s)
- No compilation errors or warnings
- All command-line tools functional

### ✅ MCP Integration Tests
All 27 MCP server integration tests pass:
```
✔ MCP Server Integration Tests (1668.141834ms)
ℹ tests 27
ℹ suites 1  
ℹ pass 27
ℹ fail 0
```

### ✅ Documentation
- README.md clearly states Xcode requirement
- docs/setup.md has detailed prerequisite section with xcode-select command
- Version numbers consistent across all configuration files

### ⚠️ Could Not Test (Requires Full Xcode)
- Swift unit tests (315+ tests) — XCTest module unavailable without full Xcode
- HomeKitHelper build — Requires Xcode app for Mac Catalyst target
- Full end-to-end integration — Requires physical HomeKit devices

## Recommendations for Future

1. **Add version consistency check to CI/CD**  
   Prevent version drift by validating all version fields match across:
   - `clawhub.json`
   - `plugin.json`  
   - `package.json`
   - Test assertions
   
2. **Single source of truth for version**  
   Consider a `VERSION` or `version.txt` file that other files read from

3. **Update Homebrew formula**  
   `Formula/homekit-automator.rb` is still at v1.1.1 — update when v1.2.0 tag is pushed

4. **Add installation verification script**  
   A `scripts/verify-install.sh` that checks:
   - Xcode.app exists (not just CLT)
   - xcode-select points to Xcode.app
   - Required dependencies installed
   - Runs a minimal test suite

## Files Changed
- `HomeKit Automator/HomeKit AutomatorTests/HomeKit_AutomatorTests.swift` — Updated version in test assertions
- `README.md` — Clarified Xcode requirement with setup command
- `docs/setup.md` — Added prominent Xcode requirement warning  
- `scripts/mcp-server/package.json` — Bumped version to 1.2.0
- `scripts/openclaw-plugin/plugin.json` — Bumped version to 1.2.0

## Testing Environment
- macOS 26.2 (Sequoia)
- Mac mini (arm64)  
- Swift 6.2.4
- Node.js v25.7.0
- Command Line Tools only (full Xcode not installed — intentionally tested this path)

Closes #TBD